### PR TITLE
downgrading to .NET 3.5

### DIFF
--- a/src/Topshelf.Quartz.StructureMap.Sample/App.config
+++ b/src/Topshelf.Quartz.StructureMap.Sample/App.config
@@ -1,29 +1,29 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-    </startup>
+        
+    <supportedRuntime version="v2.0.50727"/></startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Topshelf" publicKeyToken="b800c4cfcdeea87b" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.3.154.0" newVersion="3.3.154.0" />
+        <assemblyIdentity name="Topshelf" publicKeyToken="b800c4cfcdeea87b" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.3.154.0" newVersion="3.3.154.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Quartz" publicKeyToken="f6b8c98a402cc8a4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.3.3.0" newVersion="2.3.3.0" />
+        <assemblyIdentity name="Quartz" publicKeyToken="f6b8c98a402cc8a4" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.3.3.0" newVersion="2.3.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Ninject" publicKeyToken="c7192dc5380945e7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0" />
+        <assemblyIdentity name="Ninject" publicKeyToken="c7192dc5380945e7" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Common.Logging.Core" publicKeyToken="af08829b84f0328e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.3.1.0" newVersion="3.3.1.0" />
+        <assemblyIdentity name="Common.Logging.Core" publicKeyToken="af08829b84f0328e" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.3.1.0" newVersion="3.3.1.0" />
+        <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Topshelf.Quartz.StructureMap.Sample/Program.cs
+++ b/src/Topshelf.Quartz.StructureMap.Sample/Program.cs
@@ -4,6 +4,7 @@ using System;
 using System.Threading;
 using Quartz;
 using StructureMap;
+using StructureMap.Pipeline;
 using Topshelf.StructureMap;
 
 namespace Topshelf.Quartz.StructureMap.Sample
@@ -13,7 +14,7 @@ namespace Topshelf.Quartz.StructureMap.Sample
         static void Main() {
             HostFactory.Run(c => {
                 var container = new Container(cfg => {
-                    cfg.For<IDependency>().Use<Dependency>().AlwaysUnique();
+                    cfg.For<IDependency>().LifecycleIs(new UniquePerRequestLifecycle()).Use<Dependency>();
                     cfg.For<IScopeDependency>().Use<ScopeDependency>();
                 });
                 c.UseStructureMap(container);

--- a/src/Topshelf.Quartz.StructureMap.Sample/Topshelf.Quartz.StructureMap.Sample.csproj
+++ b/src/Topshelf.Quartz.StructureMap.Sample/Topshelf.Quartz.StructureMap.Sample.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Topshelf.Quartz.StructureMap.Sample</RootNamespace>
     <AssemblyName>Topshelf.Quartz.StructureMap.Sample</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,35 +33,30 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.3.0.0\lib\net35\Common.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.Core.3.0.0\lib\net35\Common.Logging.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Quartz, Version=2.3.3.0, Culture=neutral, PublicKeyToken=f6b8c98a402cc8a4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Quartz.2.3.3\lib\net40\Quartz.dll</HintPath>
+      <HintPath>..\packages\Quartz.2.3.3\lib\net35\Quartz.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StructureMap, Version=4.0.1.318, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\structuremap.4.0.1.318\lib\net40\StructureMap.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="StructureMap.Net4, Version=4.0.1.318, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\structuremap.4.0.1.318\lib\net40\StructureMap.Net4.dll</HintPath>
+    <Reference Include="StructureMap, Version=2.6.3.0, Culture=neutral, PublicKeyToken=e60ad81abae3c223, processorArchitecture=MSIL">
+      <HintPath>..\packages\structuremap.2.6.3\lib\StructureMap.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="Topshelf, Version=3.3.154.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
-      <HintPath>..\packages\Topshelf.3.3.1\lib\net40-full\Topshelf.dll</HintPath>
+      <HintPath>..\packages\Topshelf.3.3.1\lib\net35\Topshelf.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -70,7 +66,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="job_scheduling_data_2_0.xsd">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Topshelf.Quartz.Structuremap\Topshelf.Quartz.StructureMap.csproj">

--- a/src/Topshelf.Quartz.StructureMap.Sample/job_scheduling_data_2_0.xsd
+++ b/src/Topshelf.Quartz.StructureMap.Sample/job_scheduling_data_2_0.xsd
@@ -1,0 +1,361 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://quartznet.sourceforge.net/JobSchedulingData"
+           targetNamespace="http://quartznet.sourceforge.net/JobSchedulingData"
+           elementFormDefault="qualified"
+           version="2.0">
+
+  <xs:element name="job-scheduling-data">
+    <xs:annotation>
+      <xs:documentation>Root level node</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence maxOccurs="unbounded">
+        <xs:element name="pre-processing-commands" type="pre-processing-commandsType" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Commands to be executed before scheduling the jobs and triggers in this file.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="processing-directives" type="processing-directivesType" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Directives to be followed while scheduling the jobs and triggers in this file.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="schedule" minOccurs="0" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence maxOccurs="unbounded">
+              <xs:element name="job" type="job-detailType" minOccurs="0" maxOccurs="unbounded" />
+              <xs:element name="trigger" type="triggerType" minOccurs="0" maxOccurs="unbounded" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="version" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Version of the XML Schema instance</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="pre-processing-commandsType">
+    <xs:sequence maxOccurs="unbounded">
+      <xs:element name="delete-jobs-in-group" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Delete all jobs, if any, in the identified group. "*" can be used to identify all groups. Will also result in deleting all triggers related to the jobs.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="delete-triggers-in-group" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Delete all triggers, if any, in the identified group. "*" can be used to identify all groups. Will also result in deletion of related jobs that are non-durable.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="delete-job" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Delete the identified job if it exists (will also result in deleting all triggers related to it).</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="name" type="xs:string" />
+            <xs:element name="group" type="xs:string" minOccurs="0" />
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="delete-trigger" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Delete the identified trigger if it exists (will also result in deletion of related jobs that are non-durable).</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="name" type="xs:string" />
+            <xs:element name="group" type="xs:string" minOccurs="0" />
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="processing-directivesType">
+    <xs:sequence>
+      <xs:element name="overwrite-existing-data" type="xs:boolean" minOccurs="0" default="true">
+        <xs:annotation>
+          <xs:documentation>Whether the existing scheduling data (with same identifiers) will be overwritten. If false, and ignore-duplicates is not false, and jobs or triggers with the same names already exist as those in the file, an error will occur.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ignore-duplicates" type="xs:boolean" minOccurs="0" default="false">
+        <xs:annotation>
+          <xs:documentation>If true (and overwrite-existing-data is false) then any job/triggers encountered in this file that have names that already exist in the scheduler will be ignored, and no error will be produced.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="schedule-trigger-relative-to-replaced-trigger" type="xs:boolean" minOccurs="0" default="false">
+        <xs:annotation>
+          <xs:documentation>If true trigger's start time is calculated based on earlier run time instead of fixed value. Trigger's start time must be undefined for this to work.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="job-detailType">
+    <xs:annotation>
+      <xs:documentation>Define a JobDetail</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" />
+      <xs:element name="group" type="xs:string" minOccurs="0" />
+      <xs:element name="description" type="xs:string" minOccurs="0" />
+      <xs:element name="job-type" type="xs:string" />
+      <xs:sequence minOccurs="0">
+        <xs:element name="durable" type="xs:boolean" />
+        <xs:element name="recover" type="xs:boolean" />
+      </xs:sequence>
+      <xs:element name="job-data-map" type="job-data-mapType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="job-data-mapType">
+    <xs:annotation>
+      <xs:documentation>Define a JobDataMap</xs:documentation>
+    </xs:annotation>
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="entry" type="entryType" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="entryType">
+    <xs:annotation>
+      <xs:documentation>Define a JobDataMap entry</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="key" type="xs:string" />
+      <xs:element name="value" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="triggerType">
+    <xs:annotation>
+      <xs:documentation>Define a Trigger</xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element name="simple" type="simpleTriggerType" />
+      <xs:element name="cron" type="cronTriggerType" />
+      <xs:element name="calendar-interval" type="calendarIntervalTriggerType" />
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="abstractTriggerType" abstract="true">
+    <xs:annotation>
+      <xs:documentation>Common Trigger definitions</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" />
+      <xs:element name="group" type="xs:string" minOccurs="0" />
+      <xs:element name="description" type="xs:string" minOccurs="0" />
+      <xs:element name="job-name" type="xs:string" />
+      <xs:element name="job-group" type="xs:string" minOccurs="0" />
+      <xs:element name="priority" type="xs:nonNegativeInteger" minOccurs="0" />
+      <xs:element name="calendar-name" type="xs:string" minOccurs="0" />
+      <xs:element name="job-data-map" type="job-data-mapType" minOccurs="0" />
+      <xs:sequence minOccurs="0">
+        <xs:choice>
+          <xs:element name="start-time" type="xs:dateTime" />
+          <xs:element name="start-time-seconds-in-future" type="xs:nonNegativeInteger" />
+        </xs:choice>
+        <xs:element name="end-time" type="xs:dateTime" minOccurs="0" />
+      </xs:sequence>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="simpleTriggerType">
+    <xs:annotation>
+      <xs:documentation>Define a SimpleTrigger</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="abstractTriggerType">
+        <xs:sequence>
+          <xs:element name="misfire-instruction" type="simple-trigger-misfire-instructionType" minOccurs="0" />
+          <xs:sequence minOccurs="0">
+            <xs:element name="repeat-count" type="repeat-countType" />
+            <xs:element name="repeat-interval" type="xs:nonNegativeInteger" />
+          </xs:sequence>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="cronTriggerType">
+    <xs:annotation>
+      <xs:documentation>Define a CronTrigger</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="abstractTriggerType">
+        <xs:sequence>
+          <xs:element name="misfire-instruction" type="cron-trigger-misfire-instructionType" minOccurs="0" />
+          <xs:element name="cron-expression" type="cron-expressionType" />
+          <xs:element name="time-zone" type="xs:string" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="calendarIntervalTriggerType">
+    <xs:annotation>
+      <xs:documentation>Define a DateIntervalTrigger</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="abstractTriggerType">
+        <xs:sequence>
+          <xs:element name="misfire-instruction" type="date-interval-trigger-misfire-instructionType" minOccurs="0" />
+          <xs:element name="repeat-interval" type="xs:nonNegativeInteger" />
+          <xs:element name="repeat-interval-unit" type="interval-unitType" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:simpleType name="cron-expressionType">
+    <xs:annotation>
+      <xs:documentation>
+        Cron expression (see JavaDoc for examples)
+
+        Special thanks to Chris Thatcher (thatcher@butterfly.net) for the regular expression!
+
+        Regular expressions are not my strong point but I believe this is complete,
+        with the caveat that order for expressions like 3-0 is not legal but will pass,
+        and month and day names must be capitalized.
+        If you want to examine the correctness look for the [\s] to denote the
+        seperation of individual regular expressions. This is how I break them up visually
+        to examine them:
+
+        SECONDS:
+        (
+        ((([0-9]|[0-5][0-9])(-([0-9]|[0-5][0-9]))?,)*([0-9]|[0-5][0-9])(-([0-9]|[0-5][0-9]))?)
+        | (([\*]|[0-9]|[0-5][0-9])/([0-9]|[0-5][0-9]))
+        | ([\?])
+        | ([\*])
+        ) [\s]
+        MINUTES:
+        (
+        ((([0-9]|[0-5][0-9])(-([0-9]|[0-5][0-9]))?,)*([0-9]|[0-5][0-9])(-([0-9]|[0-5][0-9]))?)
+        | (([\*]|[0-9]|[0-5][0-9])/([0-9]|[0-5][0-9]))
+        | ([\?])
+        | ([\*])
+        ) [\s]
+        HOURS:
+        (
+        ((([0-9]|[0-1][0-9]|[2][0-3])(-([0-9]|[0-1][0-9]|[2][0-3]))?,)*([0-9]|[0-1][0-9]|[2][0-3])(-([0-9]|[0-1][0-9]|[2][0-3]))?)
+        | (([\*]|[0-9]|[0-1][0-9]|[2][0-3])/([0-9]|[0-1][0-9]|[2][0-3]))
+        | ([\?])
+        | ([\*])
+        ) [\s]
+        DAY OF MONTH:
+        (
+        ((([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1])(-([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1]))?,)*([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1])(-([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1]))?(C)?)
+        | (([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1])/([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1])(C)?)
+        | (L(-[0-9])?)
+        | (L(-[1-2][0-9])?)
+        | (L(-[3][0-1])?)
+        | (LW)
+        | ([1-9]W)
+        | ([1-3][0-9]W)
+        | ([\?])
+        | ([\*])
+        )[\s]
+        MONTH:
+        (
+        ((([1-9]|0[1-9]|1[0-2])(-([1-9]|0[1-9]|1[0-2]))?,)*([1-9]|0[1-9]|1[0-2])(-([1-9]|0[1-9]|1[0-2]))?)
+        | (([1-9]|0[1-9]|1[0-2])/([1-9]|0[1-9]|1[0-2]))
+        | (((JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(-(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?,)*(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(-(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?)
+        | ((JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)/(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))
+        | ([\?])
+        | ([\*])
+        )[\s]
+        DAY OF WEEK:
+        (
+        (([1-7](-([1-7]))?,)*([1-7])(-([1-7]))?)
+        | ([1-7]/([1-7]))
+        | (((MON|TUE|WED|THU|FRI|SAT|SUN)(-(MON|TUE|WED|THU|FRI|SAT|SUN))?,)*(MON|TUE|WED|THU|FRI|SAT|SUN)(-(MON|TUE|WED|THU|FRI|SAT|SUN))?(C)?)
+        | ((MON|TUE|WED|THU|FRI|SAT|SUN)/(MON|TUE|WED|THU|FRI|SAT|SUN)(C)?)
+        | (([1-7]|(MON|TUE|WED|THU|FRI|SAT|SUN))(L|LW)?)
+        | (([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN)#([1-7])?)
+        | ([\?])
+        | ([\*])
+        )
+        YEAR (OPTIONAL):
+        (
+        [\s]?
+        ([\*])?
+        | ((19[7-9][0-9])|(20[0-9][0-9]))?
+        | (((19[7-9][0-9])|(20[0-9][0-9]))/((19[7-9][0-9])|(20[0-9][0-9])))?
+        | ((((19[7-9][0-9])|(20[0-9][0-9]))(-((19[7-9][0-9])|(20[0-9][0-9])))?,)*((19[7-9][0-9])|(20[0-9][0-9]))(-((19[7-9][0-9])|(20[0-9][0-9])))?)?
+        )
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern
+        value="(((([0-9]|[0-5][0-9])(-([0-9]|[0-5][0-9]))?,)*([0-9]|[0-5][0-9])(-([0-9]|[0-5][0-9]))?)|(([\*]|[0-9]|[0-5][0-9])/([0-9]|[0-5][0-9]))|([\?])|([\*]))[\s](((([0-9]|[0-5][0-9])(-([0-9]|[0-5][0-9]))?,)*([0-9]|[0-5][0-9])(-([0-9]|[0-5][0-9]))?)|(([\*]|[0-9]|[0-5][0-9])/([0-9]|[0-5][0-9]))|([\?])|([\*]))[\s](((([0-9]|[0-1][0-9]|[2][0-3])(-([0-9]|[0-1][0-9]|[2][0-3]))?,)*([0-9]|[0-1][0-9]|[2][0-3])(-([0-9]|[0-1][0-9]|[2][0-3]))?)|(([\*]|[0-9]|[0-1][0-9]|[2][0-3])/([0-9]|[0-1][0-9]|[2][0-3]))|([\?])|([\*]))[\s](((([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1])(-([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1]))?,)*([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1])(-([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1]))?(C)?)|(([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1])/([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1])(C)?)|(L(-[0-9])?)|(L(-[1-2][0-9])?)|(L(-[3][0-1])?)|(LW)|([1-9]W)|([1-3][0-9]W)|([\?])|([\*]))[\s](((([1-9]|0[1-9]|1[0-2])(-([1-9]|0[1-9]|1[0-2]))?,)*([1-9]|0[1-9]|1[0-2])(-([1-9]|0[1-9]|1[0-2]))?)|(([1-9]|0[1-9]|1[0-2])/([1-9]|0[1-9]|1[0-2]))|(((JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(-(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?,)*(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(-(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?)|((JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)/(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))|([\?])|([\*]))[\s]((([1-7](-([1-7]))?,)*([1-7])(-([1-7]))?)|([1-7]/([1-7]))|(((MON|TUE|WED|THU|FRI|SAT|SUN)(-(MON|TUE|WED|THU|FRI|SAT|SUN))?,)*(MON|TUE|WED|THU|FRI|SAT|SUN)(-(MON|TUE|WED|THU|FRI|SAT|SUN))?(C)?)|((MON|TUE|WED|THU|FRI|SAT|SUN)/(MON|TUE|WED|THU|FRI|SAT|SUN)(C)?)|(([1-7]|(MON|TUE|WED|THU|FRI|SAT|SUN))?(L|LW)?)|(([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN)#([1-7])?)|([\?])|([\*]))([\s]?(([\*])?|(19[7-9][0-9])|(20[0-9][0-9]))?| (((19[7-9][0-9])|(20[0-9][0-9]))/((19[7-9][0-9])|(20[0-9][0-9])))?| ((((19[7-9][0-9])|(20[0-9][0-9]))(-((19[7-9][0-9])|(20[0-9][0-9])))?,)*((19[7-9][0-9])|(20[0-9][0-9]))(-((19[7-9][0-9])|(20[0-9][0-9])))?)?)" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="repeat-countType">
+    <xs:annotation>
+      <xs:documentation>Number of times to repeat the Trigger (-1 for indefinite)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:integer">
+      <xs:minInclusive value="-1" />
+    </xs:restriction>
+  </xs:simpleType>
+
+
+  <xs:simpleType name="simple-trigger-misfire-instructionType">
+    <xs:annotation>
+      <xs:documentation>Simple Trigger Misfire Instructions</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="SmartPolicy" />
+      <xs:pattern value="RescheduleNextWithExistingCount" />
+      <xs:pattern value="RescheduleNextWithRemainingCount" />
+      <xs:pattern value="RescheduleNowWithExistingRepeatCount" />
+      <xs:pattern value="RescheduleNowWithRemainingRepeatCount" />
+      <xs:pattern value="FireNow" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="cron-trigger-misfire-instructionType">
+    <xs:annotation>
+      <xs:documentation>Cron Trigger Misfire Instructions</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="SmartPolicy" />
+      <xs:pattern value="DoNothing" />
+      <xs:pattern value="FireOnceNow" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="date-interval-trigger-misfire-instructionType">
+    <xs:annotation>
+      <xs:documentation>Date Interval Trigger Misfire Instructions</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="SmartPolicy" />
+      <xs:pattern value="DoNothing" />
+      <xs:pattern value="FireOnceNow" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="interval-unitType">
+    <xs:annotation>
+      <xs:documentation>Interval Units</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="Day" />
+      <xs:pattern value="Hour" />
+      <xs:pattern value="Minute" />
+      <xs:pattern value="Month" />
+      <xs:pattern value="Second" />
+      <xs:pattern value="Week" />
+      <xs:pattern value="Year" />
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>

--- a/src/Topshelf.Quartz.StructureMap.Sample/packages.config
+++ b/src/Topshelf.Quartz.StructureMap.Sample/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
-  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
-  <package id="Quartz" version="2.3.3" targetFramework="net45" />
-  <package id="structuremap" version="4.0.1.318" targetFramework="net45" />
-  <package id="Topshelf" version="3.3.1" targetFramework="net45" />
+  <package id="Common.Logging" version="3.0.0" targetFramework="net35" />
+  <package id="Common.Logging.Core" version="3.0.0" targetFramework="net35" />
+  <package id="Quartz" version="2.3.3" targetFramework="net35" />
+  <package id="structuremap" version="2.6.3" targetFramework="net35" />
+  <package id="Topshelf" version="3.3.1" targetFramework="net35" />
 </packages>

--- a/src/Topshelf.Quartz.Structuremap/StructureMapJobFactory.cs
+++ b/src/Topshelf.Quartz.Structuremap/StructureMapJobFactory.cs
@@ -54,10 +54,10 @@ namespace Topshelf.Quartz.StructureMap
 				var nestedContainer = _container.GetNestedContainer();
 				job = nestedContainer.GetInstance(jobType) as IJob;
 				Containers.TryAdd(job.GetHashCode(), nestedContainer);
-				Debug.WriteLine("Start job({1}) in thread - {0}. Containers count - {2}",
+				Debug.WriteLine(string.Format("Start job({1}) in thread - {0}. Containers count - {2}",
 					Thread.CurrentThread.ManagedThreadId,
 					job.GetHashCode(),
-					Containers.Count);
+					Containers.Count));
 			}
 			catch (Exception ex) {
 				Debug.WriteLine("Exception on Starting job - ", (ex.InnerException ?? ex).Message);
@@ -79,13 +79,13 @@ namespace Topshelf.Quartz.StructureMap
 				if (container == null) { Debug.WriteLine("Container is null"); return; }
 				container.Dispose();
 			} else {
-				Debug.WriteLine("Can't find ({0})", job.GetHashCode());
+				Debug.WriteLine(string.Format("Can't find ({0})", job.GetHashCode()));
 			}
 
-			Debug.WriteLine("Return job({1}) in thread - {0}. Containers count - {2}",
+			Debug.WriteLine(string.Format("Return job({1}) in thread - {0}. Containers count - {2}",
 				Thread.CurrentThread.ManagedThreadId,
 				job.GetHashCode(),
-				Containers.Count);
+				Containers.Count));
 		}
 	}
 }

--- a/src/Topshelf.Quartz.Structuremap/StructureMapScheduleConfiguratorExtensions.cs
+++ b/src/Topshelf.Quartz.Structuremap/StructureMapScheduleConfiguratorExtensions.cs
@@ -39,7 +39,7 @@ namespace Topshelf.Quartz.StructureMap
 					c.For<IJobFactory>().Use<SimpleStructureMapJobFactory>();
 
 				c.For<ISchedulerFactory>().Use<StructureMapSchedulerFactory>();
-				c.For<IScheduler>().Use(ctx => ctx.GetInstance<ISchedulerFactory>().GetScheduler()).Singleton();
+                c.For<IScheduler>().Singleton().Use(ctx => ctx.GetInstance<ISchedulerFactory>().GetScheduler());
 			});
 
 			ScheduleJobServiceConfiguratorExtensions.SchedulerFactory = () => container.GetInstance<IScheduler>();

--- a/src/Topshelf.Quartz.Structuremap/Topshelf.Quartz.StructureMap.csproj
+++ b/src/Topshelf.Quartz.Structuremap/Topshelf.Quartz.StructureMap.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Topshelf.Quartz.StructureMap</RootNamespace>
     <AssemblyName>Topshelf.Quartz.StructureMap</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,35 +31,30 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.3.0.0\lib\net35\Common.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.Core.3.0.0\lib\net35\Common.Logging.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Quartz, Version=2.3.3.0, Culture=neutral, PublicKeyToken=f6b8c98a402cc8a4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Quartz.2.3.3\lib\net40\Quartz.dll</HintPath>
+      <HintPath>..\packages\Quartz.2.3.3\lib\net35\Quartz.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StructureMap, Version=4.0.1.318, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\structuremap.4.0.1.318\lib\net40\StructureMap.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="StructureMap.Net4, Version=4.0.1.318, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\structuremap.4.0.1.318\lib\net40\StructureMap.Net4.dll</HintPath>
+    <Reference Include="StructureMap, Version=2.6.3.0, Culture=neutral, PublicKeyToken=e60ad81abae3c223, processorArchitecture=MSIL">
+      <HintPath>..\packages\structuremap.2.6.3\lib\StructureMap.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Topshelf, Version=3.3.154.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
-      <HintPath>..\packages\Topshelf.3.3.1\lib\net40-full\Topshelf.dll</HintPath>
+    <Reference Include="System.Threading, Version=1.0.2856.102, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\TaskParallelLibrary.1.0.2856.0\lib\Net35\System.Threading.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Topshelf.StructureMap, Version=0.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Topshelf.StructureMap.0.4.0.0\lib\net45\Topshelf.StructureMap.dll</HintPath>
+    <Reference Include="Topshelf, Version=3.3.154.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Topshelf.3.3.1\lib\net35\Topshelf.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -73,11 +69,19 @@
     <Compile Include="StructureMapSchedulerFactory.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="job_scheduling_data_2_0.xsd">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
     <None Include="Topshelf.Quartz.StructureMap.nuspec" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Topshelf.StructureMap\Topshelf.StructureMap.csproj">
+      <Project>{e9a77bb2-ab70-4ce9-8cd8-9edc12e2e794}</Project>
+      <Name>Topshelf.StructureMap</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Topshelf.Quartz.Structuremap/Topshelf.Quartz.StructureMap.nuspec
+++ b/src/Topshelf.Quartz.Structuremap/Topshelf.Quartz.StructureMap.nuspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Topshelf.Quartz.StructureMap</id>
+    <id>Topshelf.Quartz.StructureMap.Net35</id>
     <version>0.6.0.0</version>
     <title>$title$</title>
     <authors>$author$</authors>

--- a/src/Topshelf.Quartz.Structuremap/job_scheduling_data_2_0.xsd
+++ b/src/Topshelf.Quartz.Structuremap/job_scheduling_data_2_0.xsd
@@ -1,0 +1,361 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://quartznet.sourceforge.net/JobSchedulingData"
+           targetNamespace="http://quartznet.sourceforge.net/JobSchedulingData"
+           elementFormDefault="qualified"
+           version="2.0">
+
+  <xs:element name="job-scheduling-data">
+    <xs:annotation>
+      <xs:documentation>Root level node</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence maxOccurs="unbounded">
+        <xs:element name="pre-processing-commands" type="pre-processing-commandsType" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Commands to be executed before scheduling the jobs and triggers in this file.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="processing-directives" type="processing-directivesType" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Directives to be followed while scheduling the jobs and triggers in this file.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="schedule" minOccurs="0" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence maxOccurs="unbounded">
+              <xs:element name="job" type="job-detailType" minOccurs="0" maxOccurs="unbounded" />
+              <xs:element name="trigger" type="triggerType" minOccurs="0" maxOccurs="unbounded" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="version" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Version of the XML Schema instance</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="pre-processing-commandsType">
+    <xs:sequence maxOccurs="unbounded">
+      <xs:element name="delete-jobs-in-group" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Delete all jobs, if any, in the identified group. "*" can be used to identify all groups. Will also result in deleting all triggers related to the jobs.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="delete-triggers-in-group" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Delete all triggers, if any, in the identified group. "*" can be used to identify all groups. Will also result in deletion of related jobs that are non-durable.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="delete-job" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Delete the identified job if it exists (will also result in deleting all triggers related to it).</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="name" type="xs:string" />
+            <xs:element name="group" type="xs:string" minOccurs="0" />
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="delete-trigger" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Delete the identified trigger if it exists (will also result in deletion of related jobs that are non-durable).</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="name" type="xs:string" />
+            <xs:element name="group" type="xs:string" minOccurs="0" />
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="processing-directivesType">
+    <xs:sequence>
+      <xs:element name="overwrite-existing-data" type="xs:boolean" minOccurs="0" default="true">
+        <xs:annotation>
+          <xs:documentation>Whether the existing scheduling data (with same identifiers) will be overwritten. If false, and ignore-duplicates is not false, and jobs or triggers with the same names already exist as those in the file, an error will occur.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ignore-duplicates" type="xs:boolean" minOccurs="0" default="false">
+        <xs:annotation>
+          <xs:documentation>If true (and overwrite-existing-data is false) then any job/triggers encountered in this file that have names that already exist in the scheduler will be ignored, and no error will be produced.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="schedule-trigger-relative-to-replaced-trigger" type="xs:boolean" minOccurs="0" default="false">
+        <xs:annotation>
+          <xs:documentation>If true trigger's start time is calculated based on earlier run time instead of fixed value. Trigger's start time must be undefined for this to work.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="job-detailType">
+    <xs:annotation>
+      <xs:documentation>Define a JobDetail</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" />
+      <xs:element name="group" type="xs:string" minOccurs="0" />
+      <xs:element name="description" type="xs:string" minOccurs="0" />
+      <xs:element name="job-type" type="xs:string" />
+      <xs:sequence minOccurs="0">
+        <xs:element name="durable" type="xs:boolean" />
+        <xs:element name="recover" type="xs:boolean" />
+      </xs:sequence>
+      <xs:element name="job-data-map" type="job-data-mapType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="job-data-mapType">
+    <xs:annotation>
+      <xs:documentation>Define a JobDataMap</xs:documentation>
+    </xs:annotation>
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="entry" type="entryType" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="entryType">
+    <xs:annotation>
+      <xs:documentation>Define a JobDataMap entry</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="key" type="xs:string" />
+      <xs:element name="value" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="triggerType">
+    <xs:annotation>
+      <xs:documentation>Define a Trigger</xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element name="simple" type="simpleTriggerType" />
+      <xs:element name="cron" type="cronTriggerType" />
+      <xs:element name="calendar-interval" type="calendarIntervalTriggerType" />
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="abstractTriggerType" abstract="true">
+    <xs:annotation>
+      <xs:documentation>Common Trigger definitions</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" />
+      <xs:element name="group" type="xs:string" minOccurs="0" />
+      <xs:element name="description" type="xs:string" minOccurs="0" />
+      <xs:element name="job-name" type="xs:string" />
+      <xs:element name="job-group" type="xs:string" minOccurs="0" />
+      <xs:element name="priority" type="xs:nonNegativeInteger" minOccurs="0" />
+      <xs:element name="calendar-name" type="xs:string" minOccurs="0" />
+      <xs:element name="job-data-map" type="job-data-mapType" minOccurs="0" />
+      <xs:sequence minOccurs="0">
+        <xs:choice>
+          <xs:element name="start-time" type="xs:dateTime" />
+          <xs:element name="start-time-seconds-in-future" type="xs:nonNegativeInteger" />
+        </xs:choice>
+        <xs:element name="end-time" type="xs:dateTime" minOccurs="0" />
+      </xs:sequence>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="simpleTriggerType">
+    <xs:annotation>
+      <xs:documentation>Define a SimpleTrigger</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="abstractTriggerType">
+        <xs:sequence>
+          <xs:element name="misfire-instruction" type="simple-trigger-misfire-instructionType" minOccurs="0" />
+          <xs:sequence minOccurs="0">
+            <xs:element name="repeat-count" type="repeat-countType" />
+            <xs:element name="repeat-interval" type="xs:nonNegativeInteger" />
+          </xs:sequence>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="cronTriggerType">
+    <xs:annotation>
+      <xs:documentation>Define a CronTrigger</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="abstractTriggerType">
+        <xs:sequence>
+          <xs:element name="misfire-instruction" type="cron-trigger-misfire-instructionType" minOccurs="0" />
+          <xs:element name="cron-expression" type="cron-expressionType" />
+          <xs:element name="time-zone" type="xs:string" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="calendarIntervalTriggerType">
+    <xs:annotation>
+      <xs:documentation>Define a DateIntervalTrigger</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="abstractTriggerType">
+        <xs:sequence>
+          <xs:element name="misfire-instruction" type="date-interval-trigger-misfire-instructionType" minOccurs="0" />
+          <xs:element name="repeat-interval" type="xs:nonNegativeInteger" />
+          <xs:element name="repeat-interval-unit" type="interval-unitType" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:simpleType name="cron-expressionType">
+    <xs:annotation>
+      <xs:documentation>
+        Cron expression (see JavaDoc for examples)
+
+        Special thanks to Chris Thatcher (thatcher@butterfly.net) for the regular expression!
+
+        Regular expressions are not my strong point but I believe this is complete,
+        with the caveat that order for expressions like 3-0 is not legal but will pass,
+        and month and day names must be capitalized.
+        If you want to examine the correctness look for the [\s] to denote the
+        seperation of individual regular expressions. This is how I break them up visually
+        to examine them:
+
+        SECONDS:
+        (
+        ((([0-9]|[0-5][0-9])(-([0-9]|[0-5][0-9]))?,)*([0-9]|[0-5][0-9])(-([0-9]|[0-5][0-9]))?)
+        | (([\*]|[0-9]|[0-5][0-9])/([0-9]|[0-5][0-9]))
+        | ([\?])
+        | ([\*])
+        ) [\s]
+        MINUTES:
+        (
+        ((([0-9]|[0-5][0-9])(-([0-9]|[0-5][0-9]))?,)*([0-9]|[0-5][0-9])(-([0-9]|[0-5][0-9]))?)
+        | (([\*]|[0-9]|[0-5][0-9])/([0-9]|[0-5][0-9]))
+        | ([\?])
+        | ([\*])
+        ) [\s]
+        HOURS:
+        (
+        ((([0-9]|[0-1][0-9]|[2][0-3])(-([0-9]|[0-1][0-9]|[2][0-3]))?,)*([0-9]|[0-1][0-9]|[2][0-3])(-([0-9]|[0-1][0-9]|[2][0-3]))?)
+        | (([\*]|[0-9]|[0-1][0-9]|[2][0-3])/([0-9]|[0-1][0-9]|[2][0-3]))
+        | ([\?])
+        | ([\*])
+        ) [\s]
+        DAY OF MONTH:
+        (
+        ((([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1])(-([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1]))?,)*([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1])(-([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1]))?(C)?)
+        | (([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1])/([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1])(C)?)
+        | (L(-[0-9])?)
+        | (L(-[1-2][0-9])?)
+        | (L(-[3][0-1])?)
+        | (LW)
+        | ([1-9]W)
+        | ([1-3][0-9]W)
+        | ([\?])
+        | ([\*])
+        )[\s]
+        MONTH:
+        (
+        ((([1-9]|0[1-9]|1[0-2])(-([1-9]|0[1-9]|1[0-2]))?,)*([1-9]|0[1-9]|1[0-2])(-([1-9]|0[1-9]|1[0-2]))?)
+        | (([1-9]|0[1-9]|1[0-2])/([1-9]|0[1-9]|1[0-2]))
+        | (((JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(-(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?,)*(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(-(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?)
+        | ((JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)/(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))
+        | ([\?])
+        | ([\*])
+        )[\s]
+        DAY OF WEEK:
+        (
+        (([1-7](-([1-7]))?,)*([1-7])(-([1-7]))?)
+        | ([1-7]/([1-7]))
+        | (((MON|TUE|WED|THU|FRI|SAT|SUN)(-(MON|TUE|WED|THU|FRI|SAT|SUN))?,)*(MON|TUE|WED|THU|FRI|SAT|SUN)(-(MON|TUE|WED|THU|FRI|SAT|SUN))?(C)?)
+        | ((MON|TUE|WED|THU|FRI|SAT|SUN)/(MON|TUE|WED|THU|FRI|SAT|SUN)(C)?)
+        | (([1-7]|(MON|TUE|WED|THU|FRI|SAT|SUN))(L|LW)?)
+        | (([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN)#([1-7])?)
+        | ([\?])
+        | ([\*])
+        )
+        YEAR (OPTIONAL):
+        (
+        [\s]?
+        ([\*])?
+        | ((19[7-9][0-9])|(20[0-9][0-9]))?
+        | (((19[7-9][0-9])|(20[0-9][0-9]))/((19[7-9][0-9])|(20[0-9][0-9])))?
+        | ((((19[7-9][0-9])|(20[0-9][0-9]))(-((19[7-9][0-9])|(20[0-9][0-9])))?,)*((19[7-9][0-9])|(20[0-9][0-9]))(-((19[7-9][0-9])|(20[0-9][0-9])))?)?
+        )
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern
+        value="(((([0-9]|[0-5][0-9])(-([0-9]|[0-5][0-9]))?,)*([0-9]|[0-5][0-9])(-([0-9]|[0-5][0-9]))?)|(([\*]|[0-9]|[0-5][0-9])/([0-9]|[0-5][0-9]))|([\?])|([\*]))[\s](((([0-9]|[0-5][0-9])(-([0-9]|[0-5][0-9]))?,)*([0-9]|[0-5][0-9])(-([0-9]|[0-5][0-9]))?)|(([\*]|[0-9]|[0-5][0-9])/([0-9]|[0-5][0-9]))|([\?])|([\*]))[\s](((([0-9]|[0-1][0-9]|[2][0-3])(-([0-9]|[0-1][0-9]|[2][0-3]))?,)*([0-9]|[0-1][0-9]|[2][0-3])(-([0-9]|[0-1][0-9]|[2][0-3]))?)|(([\*]|[0-9]|[0-1][0-9]|[2][0-3])/([0-9]|[0-1][0-9]|[2][0-3]))|([\?])|([\*]))[\s](((([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1])(-([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1]))?,)*([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1])(-([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1]))?(C)?)|(([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1])/([1-9]|[0][1-9]|[1-2][0-9]|[3][0-1])(C)?)|(L(-[0-9])?)|(L(-[1-2][0-9])?)|(L(-[3][0-1])?)|(LW)|([1-9]W)|([1-3][0-9]W)|([\?])|([\*]))[\s](((([1-9]|0[1-9]|1[0-2])(-([1-9]|0[1-9]|1[0-2]))?,)*([1-9]|0[1-9]|1[0-2])(-([1-9]|0[1-9]|1[0-2]))?)|(([1-9]|0[1-9]|1[0-2])/([1-9]|0[1-9]|1[0-2]))|(((JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(-(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?,)*(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(-(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?)|((JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)/(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))|([\?])|([\*]))[\s]((([1-7](-([1-7]))?,)*([1-7])(-([1-7]))?)|([1-7]/([1-7]))|(((MON|TUE|WED|THU|FRI|SAT|SUN)(-(MON|TUE|WED|THU|FRI|SAT|SUN))?,)*(MON|TUE|WED|THU|FRI|SAT|SUN)(-(MON|TUE|WED|THU|FRI|SAT|SUN))?(C)?)|((MON|TUE|WED|THU|FRI|SAT|SUN)/(MON|TUE|WED|THU|FRI|SAT|SUN)(C)?)|(([1-7]|(MON|TUE|WED|THU|FRI|SAT|SUN))?(L|LW)?)|(([1-7]|MON|TUE|WED|THU|FRI|SAT|SUN)#([1-7])?)|([\?])|([\*]))([\s]?(([\*])?|(19[7-9][0-9])|(20[0-9][0-9]))?| (((19[7-9][0-9])|(20[0-9][0-9]))/((19[7-9][0-9])|(20[0-9][0-9])))?| ((((19[7-9][0-9])|(20[0-9][0-9]))(-((19[7-9][0-9])|(20[0-9][0-9])))?,)*((19[7-9][0-9])|(20[0-9][0-9]))(-((19[7-9][0-9])|(20[0-9][0-9])))?)?)" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="repeat-countType">
+    <xs:annotation>
+      <xs:documentation>Number of times to repeat the Trigger (-1 for indefinite)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:integer">
+      <xs:minInclusive value="-1" />
+    </xs:restriction>
+  </xs:simpleType>
+
+
+  <xs:simpleType name="simple-trigger-misfire-instructionType">
+    <xs:annotation>
+      <xs:documentation>Simple Trigger Misfire Instructions</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="SmartPolicy" />
+      <xs:pattern value="RescheduleNextWithExistingCount" />
+      <xs:pattern value="RescheduleNextWithRemainingCount" />
+      <xs:pattern value="RescheduleNowWithExistingRepeatCount" />
+      <xs:pattern value="RescheduleNowWithRemainingRepeatCount" />
+      <xs:pattern value="FireNow" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="cron-trigger-misfire-instructionType">
+    <xs:annotation>
+      <xs:documentation>Cron Trigger Misfire Instructions</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="SmartPolicy" />
+      <xs:pattern value="DoNothing" />
+      <xs:pattern value="FireOnceNow" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="date-interval-trigger-misfire-instructionType">
+    <xs:annotation>
+      <xs:documentation>Date Interval Trigger Misfire Instructions</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="SmartPolicy" />
+      <xs:pattern value="DoNothing" />
+      <xs:pattern value="FireOnceNow" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="interval-unitType">
+    <xs:annotation>
+      <xs:documentation>Interval Units</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="Day" />
+      <xs:pattern value="Hour" />
+      <xs:pattern value="Minute" />
+      <xs:pattern value="Month" />
+      <xs:pattern value="Second" />
+      <xs:pattern value="Week" />
+      <xs:pattern value="Year" />
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>

--- a/src/Topshelf.Quartz.Structuremap/packages.config
+++ b/src/Topshelf.Quartz.Structuremap/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
-  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
-  <package id="Quartz" version="2.3.3" targetFramework="net45" />
-  <package id="structuremap" version="4.0.1.318" targetFramework="net45" />
-  <package id="Topshelf" version="3.3.1" targetFramework="net45" />
-  <package id="Topshelf.StructureMap" version="0.4.0.0" targetFramework="net45" />
+  <package id="Common.Logging" version="3.0.0" targetFramework="net35" />
+  <package id="Common.Logging.Core" version="3.0.0" targetFramework="net35" />
+  <package id="Quartz" version="2.3.3" targetFramework="net35" />
+  <package id="structuremap" version="2.6.3" targetFramework="net35" />
+  <package id="TaskParallelLibrary" version="1.0.2856.0" targetFramework="net35" />
+  <package id="Topshelf" version="3.3.1" targetFramework="net35" />
 </packages>

--- a/src/Topshelf.StructureMap/HostConfiguratorExtensions.cs
+++ b/src/Topshelf.StructureMap/HostConfiguratorExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using StructureMap;
+using StructureMap.Configuration.DSL;
 using Topshelf.HostConfigurators;
 
 namespace Topshelf.StructureMap

--- a/src/Topshelf.StructureMap/Topshelf.StructureMap.csproj
+++ b/src/Topshelf.StructureMap/Topshelf.StructureMap.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Topshelf.StructureMap</RootNamespace>
     <AssemblyName>Topshelf.StructureMap</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,19 +31,22 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="StructureMap, Version=4.0.1.318, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\structuremap.4.0.1.318\lib\net40\StructureMap.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.3.0.0\lib\net35\Common.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StructureMap.Net4, Version=4.0.1.318, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\structuremap.4.0.1.318\lib\net40\StructureMap.Net4.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.Core.3.0.0\lib\net35\Common.Logging.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="StructureMap, Version=2.6.3.0, Culture=neutral, PublicKeyToken=e60ad81abae3c223, processorArchitecture=MSIL">
+      <HintPath>..\packages\structuremap.2.6.3\lib\StructureMap.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Topshelf, Version=3.3.154.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
-      <HintPath>..\packages\Topshelf.3.3.1\lib\net40-full\Topshelf.dll</HintPath>
+      <HintPath>..\packages\Topshelf.3.3.1\lib\net35\Topshelf.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/Topshelf.StructureMap/packages.config
+++ b/src/Topshelf.StructureMap/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="structuremap" version="4.0.1.318" targetFramework="net45" />
-  <package id="Topshelf" version="3.3.1" targetFramework="net45" />
+  <package id="Common.Logging" version="3.0.0" targetFramework="net35" />
+  <package id="Common.Logging.Core" version="3.0.0" targetFramework="net35" />
+  <package id="structuremap" version="2.6.3" targetFramework="net35" />
+  <package id="Topshelf" version="3.3.1" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
not sure if this matters to anyone or not, it shows an example of downgrading the target framework and dependencies to .NET 3.5

we have a server without .NET 4.x on it where I wanted to run a windows service with Topshelf, Quartz.NET, and StructureMap so i took a quick crack at this.

I don't expect this to be merged as-is; just wonder if it might be useful.
